### PR TITLE
Added setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,20 @@
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name = "pyEcholab",
+    version = "0.0.2",
+    author = "",
+    author_email = "",
+    description= "pyEcholab is a python package for reading, writing, processing, and plotting data from Simrad/Kongsberg sonar systems.",
+    long_description = long_description,
+    long_description_content_type = "text/markdown",
+    url = "https://github.com/CI-CMG/pyEcholab",
+    packages = setuptools.find_packages(),
+    classifiers=["Programming Language :: Python :: 3",
+                 "License :: OSI Approved :: MIT License",
+                 "Operating System :: OS Independent",
+    ],
+)


### PR DESCRIPTION
We would like to add a `setup.py` file to allow pyEcholab to be `pip` installable, please.

We hope to release our RAPIDKRILL software soon, and this simple change allows us to reference pyEcholab from our own  `requirements.txt` file, simplifying installation.

Myself and Alejandro Ariza are working on this together.

Thanks!