### PR TITLE
Fix errors in EK80.py for certain raw files 

### DIFF
--- a/echolab2/instruments/EK80.py
+++ b/echolab2/instruments/EK80.py
@@ -3669,7 +3669,8 @@ class ek80_calibration(calibration):
                 else:
                     # no - this data is older. Get the value from the
                     # default_sampling_frequency dict using the transceiver type as key
-                    t_type = raw_data.configuration[idx]['transceiver_type']
+                    # ensure to capitalize the key to avoid a KeyError exception
+                    t_type = raw_data.configuration[idx]['transceiver_type'].upper()
                     param_data[ret_idx] = self.default_sampling_frequency[t_type]
                 ret_idx += 1
 

--- a/echolab2/instruments/EK80.py
+++ b/echolab2/instruments/EK80.py
@@ -3485,7 +3485,7 @@ class raw_data(ping_data):
         msg = str(self.__class__) + " at " + str(hex(id(self))) + "\n"
 
         # check if first ping is FM or CW
-        is_fm = raw_data.pulse_form[0] > 0
+        is_fm = self.pulse_form[0] > 0
 
         # Print some more info about the EK80.raw_data instance.
         n_pings = len(self.ping_time)


### PR DESCRIPTION
We recently having problems when processing this particular file:
https://github.com/iambaim/ek80_test_book/blob/master/data/N1-D20201106-T015512.raw.xz

(the original file is available here: https://love.equinor.com/Download/DownloadBlob?blobId=3199320).

The errors happened when trying to:
1. Print the `echolab2.instruments.EK80.raw_data` object from the above file
2. Run the above object `calibration()`

This pull request contains the fixes.