### PR TITLE
Switch from struct.unpack to direct byte comparison

### DIFF
--- a/echolab2/instruments/echosounder.py
+++ b/echolab2/instruments/echosounder.py
@@ -35,7 +35,6 @@ $Id$
 '''
 
 import os
-import struct
 from echolab2.instruments import EK80
 from echolab2.instruments import EK60
 
@@ -93,12 +92,12 @@ def check_filetype(filename):
     fh.close()
 
     # Return the file type based on the header
-    if struct.unpack("l4s", header)[1] == b'CON0':
-        # This is a simrad EK60 style raw file
+    if header[4:8]==b'CON0':
+        # Simrad EK60 style raw files start with P <BS> <NUL> <NUL> C O N 0
         return SIMRAD_EK60
 
-    elif struct.unpack("l4s", header)[1] == b'XML0':
-        # This is a simrad EK80 style raw file
+    elif header[4:8]==b'XML0':
+        # Simrad EK80 style raw files start with <DLE> p <NUL> <NUL> X M L 0
         return SIMRAD_EK80
 
     else:

--- a/echolab2/instruments/util/simrad_raw_file.py
+++ b/echolab2/instruments/util/simrad_raw_file.py
@@ -177,9 +177,12 @@ class RawSimradFile(BufferedReader):
 
         buf = self._read_bytes(8)
         if len(buf) != 8:
-            self._seek_bytes(-len(buf), SEEK_CUR)
-            raise DatagramReadError('Short read while getting timestamp',
-                (8, len(buf)), file_pos=(self._tell_bytes(), self.tell()))
+            if self.at_eof():
+                raise SimradEOF()
+            else:
+                self._seek_bytes(-len(buf), SEEK_CUR)
+                raise DatagramReadError('Short read while getting timestamp',
+                    (8, len(buf)), file_pos=(self._tell_bytes(), self.tell()))
 
         else:
             lowDateField, highDateField = struct.unpack('=2L', buf)
@@ -219,7 +222,7 @@ class RawSimradFile(BufferedReader):
                     file_pos=(self._tell_bytes(), self.tell()))
         else:
             dgram_type = buf
-        dgram_type = dgram_type.decode()
+        dgram_type = dgram_type.decode('iso-8859-1')
 
         #  11/26/19 - RHT
         #  As part of the rewrite of read to remove the reverse seeking,
@@ -352,7 +355,7 @@ class RawSimradFile(BufferedReader):
         #  11/26/19 - RHT - Modified this method to pass through the number of
         #  bytes read so we can bubble that up to the user.
 
-        dgram_type = raw_datagram_string[:3].decode()
+        dgram_type = raw_datagram_string[:3].decode('iso-8859-1')
         try:
             parser = self.DGRAM_TYPE_KEY[dgram_type]
         except KeyError:


### PR DESCRIPTION
The struct.unpack thing doesn't seem to work for me, first I get an error because the buffer isn't large enough, and then the unpack returns the characters immediately *after* the magic identifier.  I'm sure struct.unpack is great and all, but I just replaced it with a direct byte comparison.

I've no idea about the significance of the four first characters, but I've added a comment with the contents in the files I'm playing with, just in case they mean something.