### PR TITLE
Add dependencies for setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,5 @@ setuptools.setup(
                  "License :: OSI Approved :: MIT License",
                  "Operating System :: OS Independent",
     ],
+    install_requires=['numpy', 'pytz', 'future'],
 )


### PR DESCRIPTION
This change allows users to install pyEcholab using PIP, perhaps by placing expressions such as
`-e git+https://github.com/CI-CMG/pyEcholab.git/#egg=pyEcholab` for EK60
or
`-e git+https://github.com/CI-CMG/pyEcholab.git@RHT-EK80#egg=pyEcholab` for EK80
in their `requirements.txt` file.

