### PR TITLE
Fix for EK80 CW `get_physical_angles`

### DIFF
--- a/echolab2/instruments/EK80.py
+++ b/echolab2/instruments/EK80.py
@@ -2259,11 +2259,6 @@ class raw_data(ping_data):
 
                 # Create empty processed_data objects. We set the no_data keyword to
                 # skip creating the sample data array since we're creating it below.
-                p_data_alongship = p_data.empty_like(no_data=True)
-                p_data_alongship.is_log = False
-                p_data_athwartship = p_data.empty_like(no_data=True)
-                p_data_athwartship.is_log = False
-
                 if n_sectors == 4:
                     # average the quadrant pairs
                     yfore = np.sum(p_data[:,:,2:4], axis=2) / 2
@@ -2288,8 +2283,8 @@ class raw_data(ping_data):
                     athwartship_data = y - x
 
                 # Assign the data arrays to the processed_data objects
-                p_data_alongship.data = alongship_data
-                p_data_athwartship.data = athwartship_data
+                p_data_alongship = alongship_data
+                p_data_athwartship = athwartship_data
 
             else:
                 # We don't have enough sectors to compute angles
@@ -2307,7 +2302,7 @@ class raw_data(ping_data):
         p_data = 10 * np.log10(Per_t)
 
         if return_angles:
-            return (p_data, (p_data_alongship, p_data_athwartship))
+            return p_data, p_data_alongship, p_data_athwartship
         else:
             return p_data
 

--- a/echolab2/instruments/EK80.py
+++ b/echolab2/instruments/EK80.py
@@ -1672,7 +1672,7 @@ class raw_data(ping_data):
         # properties as this object.  Return the empty processed_data object.
         empty_obj = raw_data(self.channel_id, n_pings=n_pings,
                 n_samples=self.n_samples, rolling=self.rolling_array,
-                chunk_width=n_pings, store_power=self.store_power,
+                store_power=self.store_power,
                 store_angles=self.store_angles, store_complex=self.store_complex,
                 max_sample_number=self.max_sample_number)
 


### PR DESCRIPTION
Hi,
 
I think there is a bug in the `get_physical_angles` function from `raw_data` object when working with EK80-CW raw files.

Below is a small code,

```python
from echolab2.instruments import EK80, EK60

raw_obj = EK80.EK80()
raw_obj.read_raw("CRIMAC_2020_EK80_CW_DemoFile_GOSars.raw")
raw_data = raw_obj.get_channel_data(38000)[38000][0]
cal_obj = raw_data.get_calibration()
ang1, ang2 = raw_data.get_physical_angles(calibration = cal_obj)
```

which triggers the following error:

```python
Traceback (most recent call last):
  File "/home/user/IMR/echo-test/raw_ek80/demo_bug.py", line 7, in <module>
    ang1, ang2 = raw_data.get_physical_angles(calibration = cal_obj)
  File "/usr/local/lib/python3.9/site-packages/echolab2/instruments/EK80.py", line 2787, in get_physical_angles
    self.get_electrical_angles(calibration=calibration, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/echolab2/instruments/EK80.py", line 2908, in get_electrical_angles
    alongship, athwartship, return_indices = self._get_sample_data('angles_e',
  File "/usr/local/lib/python3.9/site-packages/echolab2/instruments/EK80.py", line 3107, in _get_sample_data
    _, raw_along_e, raw_athwart_e = self._complex_to_power(calibration, return_indices,
  File "/usr/local/lib/python3.9/site-packages/echolab2/instruments/EK80.py", line 2262, in _complex_to_power
    p_data_alongship = p_data.empty_like(no_data=True)
AttributeError: 'numpy.ndarray' object has no attribute 'empty_like'
```

This pull request is my attempt to fix it. Hopefully it won't break other things in the process.

Thank you for this very useful package!!!