### PR TITLE
Change angles in RAW0 and RAW3 datagrams from unsigned to signed bytes

### DIFF
--- a/echolab2/instruments/EK60.py
+++ b/echolab2/instruments/EK60.py
@@ -1388,8 +1388,8 @@ class EK60(object):
                     # If we have angle data, we have to convert it back to indexed and combine.
                     if hasattr(dg_objects[idx], 'angles_athwartship_e'):
                         # Convert from electrical angles to indexed.
-                        angles_athwart_data = (angles_athwart_data / raw_data.INDEX2ELEC).astype('uint8')
-                        angles_along_data = (angles_along_data / raw_data.INDEX2ELEC).astype('uint8')
+                        angles_athwart_data = (angles_athwart_data / raw_data.INDEX2ELEC).astype('int8')
+                        angles_along_data = (angles_along_data / raw_data.INDEX2ELEC).astype('int8')
                         dgram_dict['angle'] = np.column_stack((angles_athwart_data,angles_along_data))
 
                         #  set the angles bit in the beam mode

--- a/echolab2/instruments/EK80.py
+++ b/echolab2/instruments/EK80.py
@@ -1332,8 +1332,8 @@ class EK80(object):
                     # If we have angle data, we have to convert it back to indexed and combine.
                     if hasattr(dg_objects[idx], 'angles_athwartship_e'):
                         # Convert from electrical angles to indexed.
-                        angles_athwart_data = (angles_athwart_data / raw_data.INDEX2ELEC).astype('uint8')
-                        angles_along_data = (angles_along_data / raw_data.INDEX2ELEC).astype('uint8')
+                        angles_athwart_data = (angles_athwart_data / raw_data.INDEX2ELEC).astype('int8')
+                        angles_along_data = (angles_along_data / raw_data.INDEX2ELEC).astype('int8')
                         dgram['angle'] = np.column_stack((angles_athwart_data,angles_along_data))
 
                         #  set the angles bit in the datatype value

--- a/echolab2/instruments/util/simrad_parsers.py
+++ b/echolab2/instruments/util/simrad_parsers.py
@@ -1608,14 +1608,14 @@ class SimradRawParser(_SimradDatagramParser):
                     data['power'] = None
 
                 if int(data['mode']) & 0x2:
-                    data['angle'] = np.fromstring(raw_string[indx:indx + block_size], dtype='uint8')
+                    data['angle'] = np.fromstring(raw_string[indx:indx + block_size], dtype='int8')
                     data['angle'].shape = (data['count'], 2)
                 else:
                     data['angle'] = None
 
             else:
                 data['power'] = np.empty((0,), dtype='int16')
-                data['angle'] = np.empty((0,), dtype='uint8')
+                data['angle'] = np.empty((0,), dtype='int8')
 
         elif version == 3:
 
@@ -1635,7 +1635,7 @@ class SimradRawParser(_SimradDatagramParser):
                     data['power'] = None
 
                 if data['data_type'] & 0b10:
-                    data['angle'] = np.fromstring(raw_string[indx:indx + block_size], dtype='uint8')
+                    data['angle'] = np.fromstring(raw_string[indx:indx + block_size], dtype='int8')
                     data['angle'].shape = (data['count'], 2)
                     indx += block_size
                 else:
@@ -1674,7 +1674,7 @@ class SimradRawParser(_SimradDatagramParser):
 
             else:
                 data['power'] = np.empty((0,), dtype='int16')
-                data['angle'] = np.empty((0,), dtype='uint8')
+                data['angle'] = np.empty((0,), dtype='int8')
                 data['complex'] = np.empty((0,), dtype='complex64')
                 data['n_complex'] = 0
 


### PR DESCRIPTION
Angles read by pyEcholab as bytes are always positive, i.e., in the fore and starboard directions. The reason is that the bytes are parsed as `uint8`. Changing the type to `int8` fixes this problem, and the resulting angles are comparable to angles read by LSSS.