### PR TITLE
Fix `get_sv()` function for EK80 and EK60

### DIFF
--- a/echolab2/instruments/EK60.py
+++ b/echolab2/instruments/EK60.py
@@ -3181,7 +3181,7 @@ class raw_data(ping_data):
         if linear:
             # Convert to linear units
             data /= 10.00
-            data **= 10.0
+            data = 10.0 ** data
 
         # Return the result.
         return data

--- a/echolab2/instruments/EK80.py
+++ b/echolab2/instruments/EK80.py
@@ -3531,7 +3531,7 @@ class raw_data(ping_data):
         if linear:
             # Convert to linear units.
             data /= 10.0
-            data **= 10.0
+            data = 10.0 ** data
 
         # Return the result.
         return data


### PR DESCRIPTION
Hi,

Myself and  @rubenpatel71 have discovered that the `sv` values calculation using `get_sv()` function for both EK60 and EK80 seems to be off.  Instead of the current: https://github.com/CI-CMG/pyEcholab/blob/84eb4e24bd6bc88a84224d0af9bc11c6581fe3c8/echolab2/instruments/EK60.py#L3184 and https://github.com/CI-CMG/pyEcholab/blob/84eb4e24bd6bc88a84224d0af9bc11c6581fe3c8/echolab2/instruments/EK80.py#L3534, we think that it should be:
```python
data = 10 ** data
```

Borrowing the Echoview's reference [here](https://support.echoview.com/WebHelp/Reference/Algorithms/Analysis_variables/Sv_mean.htm), `sv` calculation is ![eq1](https://support.echoview.com/WebHelp/Reference/Algorithms/Analysis_variables/Equations/Sv_mean_svs.gif) so that we can re-calculate `Sv` as ![eq2](https://support.echoview.com/WebHelp/Reference/Algorithms/Analysis_variables/Equations/Sv_mean_Sv.gif).

However, this is not the case now:

```python
% python3 
Python 3.9.5 (default, May  4 2021, 03:33:11) 
[Clang 12.0.0 (clang-1200.0.32.29)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from echolab2.instruments import EK60
>>> import numpy as np
>>> raw_filename = "2019847-D20190423-T201721.raw"
>>> ek60 = EK60.EK60()
>>> ek60.read_raw(raw_filename)
>>> print(ek60)
<class 'echolab2.instruments.EK60.EK60'> at 0x10dfb18b0
    EK60 object contains data from 6 channels:
        1 :: GPT  18 kHz 00907205aeb7 1-1 ES18-11 :: power/angle (1636, 2632)
        2 :: GPT  38 kHz 00907205aebc 2-1 ES38B :: power/angle (1636, 2632)
        3 :: GPT  70 kHz 00907205aebe 3-1 ES70-7C :: power/angle (1636, 2632)
        4 :: GPT 120 kHz 00907205c48f 4-1 ES120-7C :: power/angle (1636, 2632)
        5 :: GPT 200 kHz 00907205aed2 5-1 ES200-7C :: power/angle (1636, 2632)
        6 :: GPT 333 kHz 00907205fb9c 6-1 ES333-7CD :: power/angle (1636, 2632)
    data start time: 2019-04-23T20:17:21.751
      data end time: 2019-04-23T20:44:46.093
    number of pings: 1636

>>> raw_data = ek60.raw_data['GPT  38 kHz 00907205aebc 2-1 ES38B'][0]
>>> cal_obj = raw_data.get_calibration()
>>> sv = raw_data.get_sv(calibration = cal_obj)
>>> Sv = raw_data.get_Sv(calibration = cal_obj)

>>> np.equal(np.log10(sv.data) * 10 , Sv.data)
array([[False, False, False, ..., False, False, False],
       [False, False, False, ..., False, False, False],
       [False, False, False, ..., False, False, False],
       ...,
       [False, False, False, ..., False, False, False],
       [False, False, False, ..., False, False, False],
       [False, False, False, ..., False, False, False]])

```
