### PR TITLE
Fix ek80 calibration

### DIFF
--- a/echolab2/instruments/EK80.py
+++ b/echolab2/instruments/EK80.py
@@ -4266,11 +4266,13 @@ class ek80_calibration(calibration):
                     match_idx = np.where(config_obj['pulse_duration'] == raw_data.pulse_duration[idx])[0]
                     if(len(param_data[match_idx]) != 0):
                         new_data[idx] = param_data[match_idx][0]
+                    else:
+                        new_data[idx] = 0.0
                 else:
                     if param_data.ndim == 1:
                         new_data[idx] = param_data[config_obj['pulse_duration'] == raw_data.pulse_duration[idx]][0]
                     else:
-                       new_data[idx] = param_data[idx, config_obj['pulse_duration'] == raw_data.pulse_duration[idx]][0]
+                        new_data[idx] = param_data[idx, config_obj['pulse_duration'] == raw_data.pulse_duration[idx]][0]
 
             param_data = new_data
 
@@ -4310,11 +4312,10 @@ class ek80_calibration(calibration):
                         # for FM data without BB cal even though the 'pulse_duration_fm' table exists.
                         # https://www.echoview.com/products-services/news/echoview-bug-fix-correction-to-transducer-gain-calculations-in-simrad-ek80-wideband-data
                         match_idx = np.where(config_obj['pulse_duration'] == raw_data.pulse_duration[idx])[0]
-                        if(len(param_data[match_idx]) == 0):
-                            gain = 0
-                        else:
+                        if(len(param_data[match_idx]) != 0):
                             gain = param_data[match_idx][0]
-
+                        else:
+                            gain = 0.0
                         new_data[idx] = gain + (20 * np.log10(frequency[idx] / config_obj['transducer_frequency']))
                 else:
                     # CW gain is obtained from the gain table that is indexed by pulse duration

--- a/echolab2/instruments/EK80.py
+++ b/echolab2/instruments/EK80.py
@@ -4264,7 +4264,8 @@ class ek80_calibration(calibration):
                     # For now we assume that just like with gain, we use the pulse_duration table even
                     # though there is also a pulse_duration_fm table.
                     match_idx = np.where(config_obj['pulse_duration'] == raw_data.pulse_duration[idx])[0]
-                    new_data[idx] = param_data[match_idx][0]
+                    if(len(param_data[match_idx]) != 0):
+                        new_data[idx] = param_data[match_idx][0]
                 else:
                     if param_data.ndim == 1:
                         new_data[idx] = param_data[config_obj['pulse_duration'] == raw_data.pulse_duration[idx]][0]
@@ -4309,7 +4310,10 @@ class ek80_calibration(calibration):
                         # for FM data without BB cal even though the 'pulse_duration_fm' table exists.
                         # https://www.echoview.com/products-services/news/echoview-bug-fix-correction-to-transducer-gain-calculations-in-simrad-ek80-wideband-data
                         match_idx = np.where(config_obj['pulse_duration'] == raw_data.pulse_duration[idx])[0]
-                        gain = param_data[match_idx][0]
+                        if(len(param_data[match_idx]) == 0):
+                            gain = 0
+                        else:
+                            gain = param_data[match_idx][0]
 
                         new_data[idx] = gain + (20 * np.log10(frequency[idx] / config_obj['transducer_frequency']))
                 else:


### PR DESCRIPTION
We have some EK80 files that triggered errors when calling  `get_calibration()`. I'm quoting Tomasz's email below:

> File "/Users/tf/PycharmProjects/pythonProject/echolab2/instruments/EK80.py", line 4202, in from_raw_data
    super(ek80_calibration, self).from_raw_data(raw_data,
  File "/Users/tf/PycharmProjects/pythonProject/echolab2/instruments/util/simrad_calibration.py", line 259, in from_raw_data
    self.set_attribute_from_raw(raw_data, param_name,
  File "/Users/tf/PycharmProjects/pythonProject/echolab2/instruments/util/simrad_calibration.py", line 371, in set_attribute_from_raw
    param_data = self.get_attribute_from_raw(raw_data, param_name,
  File "/Users/tf/PycharmProjects/pythonProject/echolab2/instruments/EK80.py", line 4270, in get_attribute_from_raw
    new_data[idx] = param_data[match_idx][0]
IndexError: index 0 is out of bounds for axis 0 with size 0

It seems that `param_data[match_idx]` can be empty at times. This fix can avoid the error, however I'm unsure if this is the correct way to do it.

Thanks!