### PR TITLE
Avoid TypeError if transducer is missing transducer_params_wideband

### DIFF
--- a/echolab2/instruments/util/simrad_parsers.py
+++ b/echolab2/instruments/util/simrad_parsers.py
@@ -1174,7 +1174,7 @@ class SimradXMLParser(_SimradDatagramParser):
                             
                             # Unpack the wideband configuration data
                             packed_params = {}
-                            if chan_data['transducer_params_wideband']:
+                            if 'transducer_params_wideband' in chan_data:
                                 for idx, freq in chan_data['transducer_params_wideband']['frequency']:
                                     packed_params[freq] = {'gain':chan_data['transducer_params_wideband']['gain'][idx],
                                             'beam_width_alongship':chan_data['transducer_params_wideband']['beam_width_alongship'][idx],


### PR DESCRIPTION
As written, xml _pack_contents throws a TypeError and interrupts process if a channel config is missing the transducer_params_wideband key.  


```
(file:///C:/Users/robert.levine/Anaconda3/lib/site-packages/pyecholab-0.0.2-py3.9.egg/echolab2/instruments/util/simrad_parsers.py) in _pack_contents(self, data, version)
   1176                             packed_params = {}
   1177                             if chan_data['transducer_params_wideband']:
-> 1178                                 for idx, freq in chan_data['transducer_params_wideband']['frequency']:
   1179                                     packed_params[freq] = {'gain':chan_data['transducer_params_wideband']['gain'][idx],
   1180                                             'beam_width_alongship':chan_data['transducer_params_wideband']['beam_width_alongship'][idx],

TypeError: cannot unpack non-iterable numpy.float32 object
```